### PR TITLE
Add more customization hooks for plugin docs

### DIFF
--- a/cakephpsphinx/config/all.py
+++ b/cakephpsphinx/config/all.py
@@ -44,7 +44,7 @@ source_suffix = '.rst'
 master_doc = 'contents'
 
 # General information about the project.
-project = u'CakePHP Cookbook'
+project = u'CakePHP'
 copyright = u'%d, Cake Software Foundation, Inc' % datetime.datetime.now().year
 
 

--- a/cakephpsphinx/config/all.py
+++ b/cakephpsphinx/config/all.py
@@ -15,6 +15,8 @@
 #    available through the version picker in the top navigation.
 # - `search_version` The search index prefix to use when querying
 #   https://search.cakephp.org
+# - `project` The project name to display in the header bar.
+# - `show_root_link` Whether or not to show a back to cookbook link
 
 
 # -- General configuration ---------------------------------------------------

--- a/cakephpsphinx/config/release_context.py
+++ b/cakephpsphinx/config/release_context.py
@@ -12,9 +12,11 @@ def setup(app):
     app.add_config_value('version_name', '', True)
     app.add_config_value('version_list', [], True)
     app.add_config_value('search_version', '', True)
+    app.add_config_value('show_root_link', False, True)
 
 
 def append_template_ctx(app, pagename, templatename, ctx, event_arg):
+    ctx['show_root_link'] = app.config.show_root_link
     ctx['branch'] = app.config.branch
     ctx['version_name'] = app.config.version_name
     ctx['version_list'] = app.config.version_list

--- a/cakephpsphinx/themes/cakephp/globaltoc.html
+++ b/cakephpsphinx/themes/cakephp/globaltoc.html
@@ -10,4 +10,3 @@
 <div id="sidebar-navigation" class="hidden-xs">
 	{{ toctree(maxdepth=3, titles_only=True) }}
 </div>
-

--- a/cakephpsphinx/themes/cakephp/globaltoc.html
+++ b/cakephpsphinx/themes/cakephp/globaltoc.html
@@ -8,5 +8,8 @@
     :license: BSD, see LICENSE for details.
 #}
 <div id="sidebar-navigation" class="hidden-xs">
-	{{ toctree(maxdepth=3, titles_only=True) }}
+  {% if show_root_link %}
+    <a href="https://book.cakephp.org">&#x2039; Back to CakePHP Cookbook</a>
+  {% endif %}
+  {{ toctree(maxdepth=3, titles_only=True) }}
 </div>

--- a/cakephpsphinx/themes/cakephp/layout.html
+++ b/cakephpsphinx/themes/cakephp/layout.html
@@ -20,7 +20,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset={{ encoding }}" />
     {{ metatags }}
-	<title>{{ title|striptags|e }} - {{ version }}</title>
+    <title>{{ title|striptags|e }} - {{ version }}</title>
     <link href="{{ pathto('_static/favicon.png', 1) }}" type="image/png" rel="icon" />
 
     {{ css(css_files) }}

--- a/cakephpsphinx/themes/cakephp/layout.html
+++ b/cakephpsphinx/themes/cakephp/layout.html
@@ -154,7 +154,7 @@
                             <h2>
                                 <a href="{{ pathto(master_doc) }}">
                                     <span class="glyph_range icon-submenu icon-submenu-cook">B</span>
-                                    CakePHP {{ version }} {{ version_name }} <strong>Cookbook</strong>
+                                    {{ project }} {{ version }} {{ version_name }} <strong>Cookbook</strong>
                                 </a>
                             </h2>
                         </div>


### PR DESCRIPTION
This enables plugin docs to be added as 'sidecar' sites to the main cookbook. Each plugin will have its own versioning and language layout, and have a link back to the main docs.