### PR TITLE
Removed u prefix from raw string.

### DIFF
--- a/cakephpsphinx/config/all.py
+++ b/cakephpsphinx/config/all.py
@@ -223,7 +223,7 @@ latex_show_urls = 'footnote'
 latex_domain_indices = True
 
 
-preamb = ur'''
+preamb = r'''
 % Custom colors.
 \definecolor{ChapterColor}{RGB}{201,36,52}
 \definecolor{TitleColor}{RGB}{0,0,0}


### PR DESCRIPTION
This produces incorrect characters with python 3.5.

https://github.com/cakephp/docs/pull/6345