### PR TITLE
Remove chapter navigation links.

### DIFF
--- a/cakephpsphinx/themes/cakephp-epub/layout.html
+++ b/cakephpsphinx/themes/cakephp-epub/layout.html
@@ -11,7 +11,8 @@
 
 {% set metatags = '' %}
 
-{# add only basic navigation links #}
+{# Remove most navigational links as this is an epub. #}
+{% block relbar1 %}{% endblock %}
 {% block sidebar1 %}{% endblock %}
 {% block sidebar2 %}{% endblock %}
 {% block relbar2 %}{% endblock %}


### PR DESCRIPTION
Remove the 'namespaces', and 'next' links at the top of each chapter in the epub file. These links are not useful in an epub context.