### PR TITLE
enable GA anonymize IP

### DIFF
--- a/cakephpsphinx/themes/cakephp/layout.html
+++ b/cakephpsphinx/themes/cakephp/layout.html
@@ -499,6 +499,7 @@
 <script>
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-743287-3']);
+    _gaq.push (['_gat._anonymizeIp']);
     _gaq.push(['_trackPageview']);
     (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
Under GPDR tracking via Google Analyitcs is only allowed if anonymize IP is enabled

See https://gdpr-info.eu/issues/personal-data/