### PR TITLE
Fix header hiding the root section title.

### DIFF
--- a/cakephpsphinx/themes/cakephp/static/js/header.js
+++ b/cakephpsphinx/themes/cakephp/static/js/header.js
@@ -16,9 +16,10 @@ App.Header = (function () {
             return;
         }
 
-        // If they scrolled down and are past the navbar, add class .nav-up.
-        // This is necessary so you never see what is "behind" the navbar.
-        if (st > lastScrollTop && st > navbarHeight){
+        // If they scrolled down and are half-past the navbar, add class
+        // nav-up. This is necessary so that content isn't being hidden
+        // "behind" the navbar.
+        if (st > lastScrollTop && st > (navbarHeight / 2)){
             // Scroll Down
             $header.removeClass('nav-down').addClass('nav-up');
         } else if (st + $win.height() < $(document).height()) {
@@ -39,7 +40,7 @@ App.Header = (function () {
             didScroll = true;
         });
 
-        // Debounce the header toggling to ever 250ms
+        // Debounce the header toggling to every 250ms
         var toggleHeader = function () {
             if (didScroll) {
                 hasScrolled();
@@ -48,11 +49,6 @@ App.Header = (function () {
             setTimeout(toggleHeader, 250);
         };
         setTimeout(toggleHeader, 250);
-
-        // If we're directly linking to a section, hide the nav.
-        if (window.location.hash.length) {
-            $header.addClass('nav-up');
-        }
     }
 
     return {


### PR DESCRIPTION
The problem is two-fold, the initial scroll event will basically undo the nav hiding for directly linked sections (this actually worked before), and binding the scroll detector to the full height of the navbar is too much for the root section title, it will stay hidden.

Reducing the required scroll top movement will fix the latter, and make the former redundant, as the automatic scrolling that happens for a directly linked root section will be enough to unhide it.