### PR TITLE
Update OpenSearchDescription for CakePHP 4

### DIFF
--- a/cakephpsphinx/themes/cakephp/layout.html
+++ b/cakephpsphinx/themes/cakephp/layout.html
@@ -49,7 +49,7 @@
         {%- endif -%}
     {% endfor %}
 
-    <link rel="search" type="application/opensearchdescription+xml" title="Search within {{ docstitle }}" href="{{ pathto('_static/opensearchdescription-book-3-x.xml', 1) }}">
+    <link rel="search" type="application/opensearchdescription+xml" title="Search within {{ docstitle }}" href="{{ pathto('_static/opensearchdescription-book-4-x.xml', 1) }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 {%- block linktags %}

--- a/cakephpsphinx/themes/cakephp/static/opensearchdescription-book-4-x.xml
+++ b/cakephpsphinx/themes/cakephp/static/opensearchdescription-book-4-x.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>CakePHP Book 3.x</ShortName>
+  <ShortName>CakePHP Book 4.x</ShortName>
   <Description>The CakePHP cookbook, is an openly developed community editable documentation project.</Description>
     <Image height="16" width="16" type="image/x-icon">https://book.cakephp.org/favicon.ico</Image>  
   
   <Url type="text/html"
        method="get"
-       template="https://book.cakephp.org/3.0/en/search.html?q={searchTerms}&amp;check_keywords=yes&amp;area=default">
+       template="https://book.cakephp.org/4.0/en/search.html?q={searchTerms}&amp;check_keywords=yes&amp;area=default">
   </Url>
   <OutputEncoding>UTF-8</OutputEncoding>
   <InputEncoding>UTF-8</InputEncoding>


### PR DESCRIPTION
## Usage
We should be able to right-click the omnibar and add CakePHP docs search as a search engine: 
![image](https://user-images.githubusercontent.com/2078163/191337407-22629fad-6e08-4f86-a3ab-614c233d73c4.png)

## Issue 
Installs the search plugin for CakePHP 3, despite the docs being CakePHP 4
`Firefox Developer Edition could not install the search plugin from "https://book.cakephp.org/4/en/_static/opensearchdescription-book-3-x.xml" because an engine with the same name already exists.`

## Quick fix
**This PR**, where it does the same thing as [this commit](https://github.com/cakephp/docs/commit/f8d037c8d06c8766e083a52e4755fe43a79b115f?diff=unified#diff-f18bc27d1c0df2c75d5f011d4b562136248c8a82f888da0ae41af8d16f505f25) did for CakePHP 2 --> 3.

## Better, long-term solution **[TODO]**
The opensearchdescription file should be moved from https://github.com/cakephp/sphinxtheme/ to https://github.com/cakephp/docs/ as it is related to the docs, not the theme. 


I may be able to provide this solution later, but for now I wanted the fix to be in there at least. 