### PR TITLE
Replace hardcoded repo string with variable

### DIFF
--- a/cakephpsphinx/themes/cakephp/layout.html
+++ b/cakephpsphinx/themes/cakephp/layout.html
@@ -393,11 +393,11 @@
                 </div>
 
                 <div class="col-sm-3 col-xs-6">
-                    <iframe title="github star count" src="https://ghbtns.com/github-btn.html?user=cakephp&amp;repo=cakephp&amp;type=star&amp;count=true&amp;size=small" frameborder="0" scrolling="0" width="120px" height="30px"></iframe>
+                    <iframe title="github star count" src="https://ghbtns.com/github-btn.html?user=cakephp&amp;repo={{ repository }}&amp;type=star&amp;count=true&amp;size=small" frameborder="0" scrolling="0" width="120px" height="30px"></iframe>
                 </div>
 
                 <div class="col-sm-3 col-xs-6">
-                    <iframe title="github fork count" src="https://ghbtns.com/github-btn.html?user=cakephp&amp;repo=cakephp&amp;type=fork&amp;count=true&amp;size=small" frameborder="0" scrolling="0" width="120px" height="30px"></iframe>
+                    <iframe title="github fork count" src="https://ghbtns.com/github-btn.html?user=cakephp&amp;repo={{ repository }}&amp;type=fork&amp;count=true&amp;size=small" frameborder="0" scrolling="0" width="120px" height="30px"></iframe>
                 </div>
             </div>
 


### PR DESCRIPTION
Replace "cakephp" string with {{ repository }} variable for GitHub Stars and Forks buttons 