### PR TITLE
sphinx php parameter rendering hard to read

### DIFF
--- a/cakephpsphinx/themes/cakephp/static/css/default.css
+++ b/cakephpsphinx/themes/cakephp/static/css/default.css
@@ -711,7 +711,7 @@ dt tt {
 }
 .field-list,
 .field-list strong {
-  font-size: 110%;
+  font-size: 12px;
   font-family: "Roboto Mono", "Consolas", "Monaco", monospace;
   color: #003d4c;
   font-weight: normal;


### PR DESCRIPTION
This is related to raised issue at cakephp/docs: sphinx php parameter rendering hard to read (#7096 cakephp/docs)

ps: sorry, not following the pypi upload procedure.