### PR TITLE
try to fix version links loosing current page

### DIFF
--- a/cakephpsphinx/themes/cakephp/layout.html
+++ b/cakephpsphinx/themes/cakephp/layout.html
@@ -246,9 +246,15 @@
                                             {% endfor %}
                                             <ul class="dropdown-menu">
                                                 {% for item in version_list %}
-                                                    <li><a href="https://book.cakephp.org/{{ item['number'] }}/{{ short_lang }}">
-                                                        {{ item['title'] }}
-                                                    </a></li>
+                                                <li>
+                                                    {%- if has_lang(language, pagename) -%}
+                                                    <a lang="{{ lang }}" href="{{ lang_link(language, pagename) }}">
+                                                        {%- else -%}
+                                                        <a href="https://book.cakephp.org/{{ item['number'] }}/{{ short_lang }}">
+                                                            {%- endif -%}
+                                                            {{ item['title'] }}
+                                                        </a>
+                                                </li>
                                                 {% endfor %}
                                             </ul>
                                         </li>


### PR DESCRIPTION
Its pretty annoying that changing versions looses the current page even though the other version 100% has the same page.

E.g.
https://book.cakephp.org/4/en/core-libraries/events.html
and
https://book.cakephp.org/5/en/core-libraries/events.html

If you click on the `5.x` link the `4.x` version you get linked back to https://book.cakephp.org/5/en/index.html

With this the same logic has been used, which is already present for the language switcher.

I believe this works but wasn't able to test it, because locally generating these docs only generates the checkout out version.