### PR TITLE
Add canonical_version link

### DIFF
--- a/cakephpsphinx/config/all.py
+++ b/cakephpsphinx/config/all.py
@@ -24,7 +24,8 @@
 #   unstable or pre-release version of a plugin/cakephp.
 # - `hide_page_contents` A set of pages that don't show 'page contents'
 #   section. Default value is `('search', 'index', 'contents', '404')`
-
+# - `canonical_version` A project/version value that is used in rel=canonical
+#   link elements.
 
 
 # -- General configuration ---------------------------------------------------

--- a/cakephpsphinx/config/release_context.py
+++ b/cakephpsphinx/config/release_context.py
@@ -38,3 +38,4 @@ def append_template_ctx(app, pagename, templatename, ctx, event_arg):
     ctx['is_security'] = app.config.is_security
     ctx['is_eol'] = app.config.is_eol
     ctx['hide_page_contents'] = app.config.hide_page_contents
+    ctx['canonical_version'] = app.config.canonical_version

--- a/cakephpsphinx/themes/cakephp/layout.html
+++ b/cakephpsphinx/themes/cakephp/layout.html
@@ -86,7 +86,7 @@
     {%- endif %}
 
     {% for item in version_list if 'current' in item and item['current'] %}
-    <link rel="canonical" href="https://book.cakephp.org/{{ item['number'] }}/{{ language }}/{{ pagename }}.html" />
+    <link rel="canonical" href="https://book.cakephp.org/{{ canonical_version|default(item['number']) }}/{{ language }}/{{ pagename }}.html" />
     {% endfor %}
 {%- endblock %}
   </head>


### PR DESCRIPTION
Many of docs versions have canonical links that point to themselves. This makes it hard for new versions to do well in search rankings.

We can add config values to older versions to have them reference the new version.

cc @LordSimal 